### PR TITLE
Fix for caching and pagination link problems.

### DIFF
--- a/app/controllers/abstracts_controller.rb
+++ b/app/controllers/abstracts_controller.rb
@@ -12,17 +12,11 @@ class AbstractsController < ApplicationController
   require 'pubmed_utilities'  #loads including 'pubmed_config'  'bio' (bioruby) and 
 
   def index
-    year = handle_year()
-    redirect_to abstracts_by_year_url(:id => year, :page => '1')
+    redirect_to current_abstracts_url
   end
   
   def current
-    params[:id]=LatticeGridHelper.year_array[0].to_s
-    pre_list(params[:id])
-    @abstracts = Abstract.display_data( params[:id], params[:page] )
-    list_heading(params[:id])
-    @do_pagination = "1"
-    render :action => 'year_list'
+    index
   end
 
   def journal_list

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,12 @@ module ApplicationHelper
     @year
   end
 
+  # Overrides `current_abstracts_url` from the router.
+  def current_abstracts_url
+    year = handle_year()
+    abstracts_by_year_url(:id => year, :page => '1')
+  end
+
   def base_path(remove_trailing_id=false)
     the_path=request.env['REQUEST_URI']
     if remove_trailing_id and the_path =~ /\/[0-9]+$/

--- a/lib/tasks/clean_and_curl.rake
+++ b/lib/tasks/clean_and_curl.rake
@@ -85,7 +85,6 @@ namespace :cache do
 
   def abstracts
     year_array = LatticeGridHelper.year_array()
-    run_curl current_abstracts_url
     run_curl tag_cloud_abstracts_url
     year_array.each do |year|
       do_abstracts_for_year(year.to_s)

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,9 @@
-<script language="JavaScript">
-<!-- begin script
-	window.location.replace("abstracts/current");
-// end script -->
-</SCRIPT>
-<HTML>
-<HEAD>
-        <META HTTP-EQUIV=REFRESH CONTENT="0;URL=abstracts/current">
-</HEAD>
-</HTML>
-
+<html>
+<head>
+	<script language="JavaScript">
+		window.location.replace("abstracts/" + new Date().getFullYear() + "/year_list/1");
+	</script>
+	<!-- If the user doesn't have Javascript, figure out the current year server-side. -->
+	<meta http-equiv=refresh content="0;url=abstracts/current">
+</head>
+</html>


### PR DESCRIPTION
I found two bugs:
- From the LatticeGrid home page (/abstracts/current), clicking on "no pagination" results in a 404.
- From the LatticeGrid home page, clicking on pages other than the first one (for example, /abstracts/2012/current/10) results in a page hit that is not cached.  We're running a rather underpowered server, so this is a fairly significant difference for us.

Both of these issues stem from the fact that /abstracts/current effectively is an identical view onto the /abstracts/(current_year)/year_list pages.

I attached a commit that fixes this by making /abstracts/current a redirect page to the current year list:
- Change index.html to redirect JavaScript-enabled users directly to the right page.  Without JS, they pass through the (slower) Ruby redirect page.
- Override `current_abstracts_url` to point directly to the year list.
- Change `AbstractController#current` to a redirect page.
- Caching for "/abstracts/current" is no longer necessary.
